### PR TITLE
Change from * to warn by default for localX services

### DIFF
--- a/src/common/etc/rsyslog.d/xenserver.conf
+++ b/src/common/etc/rsyslog.d/xenserver.conf
@@ -12,7 +12,7 @@ $SystemLogRateLimitInterval 0
 # Log by facility.
 kern.*							-/var/log/kern.log
 # dlm_controld logs to syslog local4
-daemon.*;local4.*					-/var/log/daemon.log
+daemon.*;local4.warn					-/var/log/daemon.log
 user.*							-/var/log/user.log
 
 # The authpriv file has restricted access.
@@ -28,19 +28,19 @@ cron.*							-/var/log/cron
 local7.*						/var/log/boot.log
 
 # Xapi rbac audit log echoes to syslog local6
-local6.*						-/var/log/audit.log
+local6.warn						-/var/log/audit.log
 
 # Xapi, xenopsd echo to syslog local5
-local5.*						-/var/log/xensource.log
+local5.warn						-/var/log/xensource.log
 
 # xenstore access to syslog local3
-local3.info						-/var/log/xenstored-access.log
+local3.warn						-/var/log/xenstored-access.log
 
 # Storage Manager to syslog local2
-local2.*						-/var/log/SMlog
+local2.warn						-/var/log/SMlog
 
 # Scheduled snapshots to syslog local1
-local1.*						-/var/log/VMSSlog
+local1.warn						-/var/log/VMSSlog
 
 # xcp-rrdd-plugins (info and above) to local0
 local0.info						-/var/log/xcp-rrdd-plugins.log


### PR DESCRIPTION
On my host, I see many debug messages per minute (sometimes many per second) from `xenopsd-xc` and `xapi` in my `/var/log/xensource.log`. Likewise, there are lots of debug messages in `/var/log/daemon.log` from `squeezed`. Similarly, `xenstored-access.log` appears to be logging every write event. This is just filling up the log files with junk. While it is true that the logs are rotated just fine and it's not going to fill the filesystem, it's still just processing a ton of useless data for no benefit. The vast majority of the time most admins have no need for debugging info. It should be necessary to turn on `debug` level information when troubleshooting. All this stems from the default `xenserver.conf` that gets loaded to `/etc/rsyslog.d`. All the `localX` services (which correspond to various Xen components) are set to log `*`, which includes debug-level messages.

This patch sets the default log level to be `warn`, which seems like a more sensible default for production use. I am not 100% sure what people expect, so perhaps `info` is the better default level. But `debug` is rarely the right default.