### PR TITLE
Add a depmod.d config for the "override" dir

### DIFF
--- a/src/xenserver/etc/depmod.d/00-xcpng-override.conf
+++ b/src/xenserver/etc/depmod.d/00-xcpng-override.conf
@@ -1,0 +1,1 @@
+search override


### PR DESCRIPTION
Putting this `search override` in a file sorting before `dist.conf` ensures `override` is searched before the standard dirs declared there.