### PR TITLE
xapi.service: do not pull qemuback.service unconditionally

### DIFF
--- a/src/common/etc/systemd/system/xapi.service.d/local.conf
+++ b/src/common/etc/systemd/system/xapi.service.d/local.conf
@@ -1,3 +1,3 @@
 [Unit]
-Wants=tapback.service qemuback.service
-After=tapback.service qemuback.service
+Wants=tapback.service
+After=tapback.service


### PR DESCRIPTION
This service is provided by an extra package, not shipped yet in 8.3 as no driver uses it.