### PR TITLE
Don't generate link-local address for interfaces

### DIFF
--- a/src/common/etc/sysctl.d/91-net-ipv6.conf
+++ b/src/common/etc/sysctl.d/91-net-ipv6.conf
@@ -1,3 +1,12 @@
 # Disable IPv6 on interfaces
 net.ipv6.conf.all.disable_ipv6 = 1
 net.ipv6.conf.default.disable_ipv6 = 1
+
+# Defines how link-local and autoconf addresses are generated.
+# A value of 1 does the following:
+#   - do not generate a link-local address
+#   - use EUI64 for addresses generated from autoconf
+# "all" only affects the current state of all interfaces
+# "default" affect all interfaces that are created in the future
+net.ipv6.conf.all.addr_gen_mode=1
+net.ipv6.conf.default.addr_gen_mode=1


### PR DESCRIPTION
When creating the bridge for virtual machines we don't want to set link-local address because it will give an access to the host for VMs. Required link-local are managed by XAPI directly.