### PR TITLE
fix(curl) On 8.2 TLS failed issue with .curlrc

### DIFF
--- a/src/common/root/.curlrc
+++ b/src/common/root/.curlrc
@@ -1,3 +1,3 @@
 # See https://curl.haxx.se/docs/ssl-ciphers.html for the NSS names
-ciphers = ecdhe_rsa_aes_256_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,rsa_aes_256_cbc_sha_256,rsa_aes_128_cbc_sha_256
+ciphers = ecdhe_rsa_aes_256_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,rsa_aes_256_cbc_sha_256,rsa_aes_128_cbc_sha_256,ECDHE-ECDSA-AES128-GCM-SHA256
 tlsv1.2


### PR DESCRIPTION
Using openssl too restrictively with the .curlrc file prevents users from installing a xoa that requires more recent certificates (related to openssl). Therefore, it is better to add a certificate that xoa knows and can use in order to facilitate deployment for users while ensuring secure communications.