### PR TITLE
Fix cipher in .curlrc

### DIFF
--- a/src/common/root/.curlrc
+++ b/src/common/root/.curlrc
@@ -1,3 +1,3 @@
 # See https://curl.haxx.se/docs/ssl-ciphers.html for the NSS names
-ciphers = ecdhe_rsa_aes_256_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,rsa_aes_256_cbc_sha_256,rsa_aes_128_cbc_sha_256,ECDHE-ECDSA-AES128-GCM-SHA256
+ciphers = ECDHE-RSA-AES256-SHA384,ECDHE-RSA-AES256-GCM-SHA384,AES256-SHA256,AES128-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256
 tlsv1.2


### PR DESCRIPTION
openssl has been imported in xcp-ng-rpms with the same version of 8.3. So some ciphers in the .curlrc list seem to be out of date.

(I replaced the ciphers from 8.3, and they are exactly the same, they are just in the right format.)