### PR TITLE
s/c/e/p/xcp-ng-prompt.sh: Fix prompt on testing tput output

### DIFF
--- a/src/common/etc/profile.d/xcp-ng-prompt.sh
+++ b/src/common/etc/profile.d/xcp-ng-prompt.sh
@@ -3,7 +3,7 @@
 ########################################
 
 # BASH : Configure things differently if current terminal has >= 8 colors.
-if [ "$PS1" ] && [ $(tput colors 2>/dev/null) -ge 8 ]; then
+if [ "$PS1" ] && [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
     PS1='\[\e[0;38;5;160m\][\[\e[0;2m\]\A \[\e[0;1;38;5;105m\]\h \[\e[0m\]\W\[\e[0;38;5;160m\]]\[\e[0m\]\$ '
 else
     PS1='[\A \h \W]\$ '


### PR DESCRIPTION
Harden the prompt test, in case tput is failing or output is null.

cc: @stormi @ydirson 