### PR TITLE
s/c/e/profile.d/history.sh: Add timestamps to history

### DIFF
--- a/src/common/etc/profile.d/history.sh
+++ b/src/common/etc/profile.d/history.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+HISTTIMEFORMAT="%Y-%m-%d %T "
+export HISTTIMEFORMAT


### PR DESCRIPTION
... using HISTTIMEFORMAT

The ISO prefix is used because easier to read/parse and less prone to ambuiguity (EU vs US).

The file structure is aligned to xs.sh